### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The app works on Mac, Linux and Windows.
 - Things that are overlooked by most HN apps weren't forgotten, stuff like
   displaying HN polls, rendering PDFs or not showing a website for Ask HN posts
 - Automatically loads new articles if you scrolled down far enough
-- It's Open Source, you can change it however you like! :)
+- It's Open Source + [Free Software](https://www.gnu.org/philosophy/free-sw.html), you can change it however you like! :)
 
 ![](https://i.imgur.com/L3eyTqZ.png)
 ![](https://i.imgur.com/4e36YVo.png)
@@ -71,3 +71,8 @@ $ npm run package-all # for all platforms
 ### Ideas
 
 While I implemented all of the features I definitely wanted, there's also a [list of feature ideas](https://github.com/florian/HNClient/blob/master/ideas.md).
+
+#### Notes
+
+- This is a client for Hacker News hosted on ycombinator.
+[news.ycombinator.com](https://news.ycombinator.com/)

--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ While I implemented all of the features I definitely wanted, there's also a [lis
 
 #### Notes
 
-- This is a client for Hacker News hosted on ycombinator.
+- This is a client for Hacker News hosted on ycombinator: 
 [news.ycombinator.com](https://news.ycombinator.com/)


### PR DESCRIPTION
**Clarification**: This PR helps clarify that this is an MIT Licensed client for hacker news hosted at: https://news.ycombinator.com/

**Why is this important**: There are other hacker news websites. This just helps state which one this uses. :)